### PR TITLE
New terms get added to the top of the index not the bottom

### DIFF
--- a/src/js/views/index-view.js
+++ b/src/js/views/index-view.js
@@ -90,7 +90,7 @@ function(Backbone, _, $, IndexTerm, Dishes, TermView) {
 
         addTerm: function(term) {
             var view = new TermView({model: term});
-            this.$el.append(view.render());
+            this.$el.prepend(view.render());
         },
         
         editIndexTerm: function(event) { 


### PR DESCRIPTION
This seems a more desirable behavior if many terms will be created in a session. "Older" terms will scroll out of view while recent actions will always be visible
