### PR TITLE
Undo set dishes at index term creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - "0.12"
 before_install: npm install -g grunt-cli
+sudo: false

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-requirejs": "^0.4.4",
-    "grunt-mocha-phantomjs": "^0.6.0"
+    "grunt-mocha-phantomjs": "^0.6.0",
+    "phantomjs": "1.9.7-15"
   },
   "scripts": {
     "postinstall" : "node_modules/.bin/bower install",

--- a/src/js/collections/index.js
+++ b/src/js/collections/index.js
@@ -86,8 +86,7 @@ define([
             var uploadBody = [];
             this.each(function(model) {
 
-                if (model.has('dishes_aggregated') 
-                        && model.has('_session_id')) {
+                if (model.has('_session_id')) {
 
                     var id = model.get('_session_id');
                     model.set('term_id', id);

--- a/src/js/templates/edit-template.html
+++ b/src/js/templates/edit-template.html
@@ -2,3 +2,14 @@
 
 <h5>{{ index_term }}</h5>
 <p>created by {{ responsible }} at {{ date_created }}</p>
+
+<h5>Exemplars</h5>
+<ul>
+    {{#each dishes_aggregated}}
+    <li>
+        <a href="http://menus.nypl.org/menu_items/{{#this}}/edit">
+            http://menus.nypl.org/menu_items/{{#this}}/edit
+        </a>
+    </li>
+    {{/each}}
+</ul>

--- a/src/js/templates/edit-template.html
+++ b/src/js/templates/edit-template.html
@@ -7,7 +7,7 @@
 <ul>
     {{#each dishes_aggregated}}
     <li>
-        <a href="http://menus.nypl.org/menu_items/{{#this}}/edit">
+        <a href="http://menus.nypl.org/menu_items/{{#this}}/edit" target="_blank">
             http://menus.nypl.org/menu_items/{{#this}}/edit
         </a>
     </li>

--- a/src/js/templates/edit-template.html
+++ b/src/js/templates/edit-template.html
@@ -3,7 +3,7 @@
 <h5>{{ index_term }}</h5>
 <p>created by {{ responsible }} at {{ date_created }}</p>
 
-<h5>Exemplars</h5>
+<h5>variants:</h5>
 <ul>
     {{#each dishes_aggregated}}
     <li>

--- a/src/js/templates/edit-template.html
+++ b/src/js/templates/edit-template.html
@@ -7,8 +7,8 @@
 <ul>
     {{#each dishes_aggregated}}
     <li>
-        <a href="http://menus.nypl.org/menu_items/{{#this}}/edit" target="_blank">
-            http://menus.nypl.org/menu_items/{{#this}}/edit
+        <a href="http://menus.nypl.org/menu_items/{{this}}/edit" target="_blank">
+            http://menus.nypl.org/menu_items/{{this}}/edit
         </a>
     </li>
     {{/each}}

--- a/src/js/templates/edit-template.html
+++ b/src/js/templates/edit-template.html
@@ -7,8 +7,8 @@
 <ul>
     {{#each dishes_aggregated}}
     <li>
-        <a href="http://menus.nypl.org/menu_items/{{this}}/edit" target="_blank">
-            http://menus.nypl.org/menu_items/{{this}}/edit
+        <a href="http://menus.nypl.org/dishes/{{this}}" target="_blank">
+            http://menus.nypl.org/dishes/{{this}}
         </a>
     </li>
     {{/each}}

--- a/src/js/templates/term-template.html
+++ b/src/js/templates/term-template.html
@@ -1,10 +1,8 @@
 <li data-fingerprint="{{fingerprint_value}}">
         <a href="#">{{index_term}}</a>
-        {{#if dishes_aggregated}}
-            {{#if saved}}
-                <span class="glyphicon glyphicon-ok save-confirmed" aria-hidden="true"></span>
-            {{else}}
-                <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
-            {{/if}}
+        {{#if saved}}
+            <span class="glyphicon glyphicon-ok save-confirmed" aria-hidden="true"></span>
+        {{else}}
+            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
         {{/if}}
 </li>

--- a/src/js/templates/term-template.html
+++ b/src/js/templates/term-template.html
@@ -2,7 +2,5 @@
         <a href="#">{{index_term}}</a>
         {{#if saved}}
             <span class="glyphicon glyphicon-ok save-confirmed" aria-hidden="true"></span>
-        {{else}}
-            <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
         {{/if}}
 </li>

--- a/src/js/views/modal-manager-view.js
+++ b/src/js/views/modal-manager-view.js
@@ -52,24 +52,24 @@ define([
             var model = data
             , dishCollex = new Dishes();
 
-            var setDishes = function() {
+            var showDishes = function() {
                 var dishIds = _.map(dishCollex.pluck('dish_id'), function(id){ return Number(id).toFixed();});
                 model.set('dishes_aggregated', dishIds);
+
+                var $termEditor = this.editTemplate(model.toJSON());
+
+                $('#info-modal .modal-body').empty();
+                $('#info-modal .modal-body').append($termEditor);
+                this.openModal = true;
+                $('#info-modal').modal();
             };
 
             dishCollex.fetch(Queries.getAggregatedDishes(model.get('fingerprint_value')));
-            this.listenTo(dishCollex, 'reset', setDishes);
+            this.listenTo(dishCollex, 'reset', showDishes);
 
             // Clean up by destroying all the dish models rather by reset
             _.each(_.clone(dishCollex.models), function(model) { model.destroy(); });
 
-
-            var $termEditor = this.editTemplate(model.toJSON());
-
-            $('#info-modal .modal-body').empty();
-            $('#info-modal .modal-body').append($termEditor);
-            this.openModal = true;
-            $('#info-modal').modal();
         },
 
         createIssue: function(data) {

--- a/src/js/views/modal-manager-view.js
+++ b/src/js/views/modal-manager-view.js
@@ -7,10 +7,12 @@ define([
         'handlebars',
         'src/js/helpers/keybindings',
         'src/js/models/issue',
+        'src/js/collections/dishes',
+        'src/js/helpers/queries',
         'text!src/js/templates/form-template.html',
         'text!src/js/templates/help-template.html',
         'text!src/js/templates/edit-template.html'
-], function(Backbone, _, $, Handlebars, Keybindings, Issue, formTemplate, helpTemplate, editTemplate) {
+], function(Backbone, _, $, Handlebars, Keybindings, Issue, Dishes, Queries, formTemplate, helpTemplate, editTemplate) {
     'use strict';
 
     var ModalView = Backbone.View.extend({

--- a/src/js/views/modal-manager-view.js
+++ b/src/js/views/modal-manager-view.js
@@ -47,7 +47,20 @@ define([
         },
 
         editTerm: function(data) {
-            var model = data;
+            var model = data
+            , dishCollex = new Dishes();
+
+            var setDishes = function() {
+                var dishIds = _.map(dishCollex.pluck('dish_id'), function(id){ return Number(id).toFixed();});
+                model.set('dishes_aggregated', dishIds);
+            };
+
+            dishCollex.fetch(Queries.getAggregatedDishes(model.get('fingerprint_value')));
+            this.listenTo(dishCollex, 'reset', setDishes);
+
+            // Clean up by destroying all the dish models rather by reset
+            _.each(_.clone(dishCollex.models), function(model) { model.destroy(); });
+
 
             var $termEditor = this.editTemplate(model.toJSON());
 

--- a/ssmmfm.py
+++ b/ssmmfm.py
@@ -1,11 +1,13 @@
 from requests_oauthlib import OAuth2Session
-from flask import Flask, request, render_template, render_template, redirect, session, url_for
+from flask import Flask, request, render_template, redirect, session, url_for
 from werkzeug.contrib.fixers import ProxyFix
 from flask.json import jsonify
-import os, json
+import os
+import json
 
 app = Flask(__name__)
 app.config.from_object('config')
+
 
 @app.route('/')
 def index():
@@ -14,13 +16,15 @@ def index():
 
 @app.route('/robots.txt')
 def robots():
-     return app.send_static_file('robots.txt')
+    return app.send_static_file('robots.txt')
 
 
 @app.route("/login")
 def login():
-    github = OAuth2Session(app.config['CLIENT_ID'], scope=['public_repo', 'write:org'])
-    authorization_url, state = github.authorization_url(app.config['AUTH_BASE_URL'])
+    github = OAuth2Session(app.config['CLIENT_ID'],
+                           scope=['public_repo', 'write:org'])
+    authorization_url, state = github.authorization_url(
+        app.config['AUTH_BASE_URL'])
 
     session['oauth_state'] = state
     return redirect(authorization_url)
@@ -28,10 +32,11 @@ def login():
 
 @app.route("/callback", methods=["GET"])
 def callback():
-    github = OAuth2Session(app.config['CLIENT_ID'], state=session['oauth_state'])
+    github = OAuth2Session(app.config['CLIENT_ID'],
+                           state=session['oauth_state'])
     token = github.fetch_token(app.config['TOKEN_URL'],
-                                    client_secret=app.config['CLIENT_SECRET'],
-                                    authorization_response=request.url)
+                               client_secret=app.config['CLIENT_SECRET'],
+                               authorization_response=request.url)
 
     session['oauth_token'] = token
     return redirect(url_for('.ssmmfm'))
@@ -47,7 +52,8 @@ def ssmmfm():
 
 @app.route("/user", methods=["GET"])
 def user_data():
-    github = OAuth2Session(app.config['CLIENT_ID'], token=session['oauth_token'])
+    github = OAuth2Session(app.config['CLIENT_ID'],
+                           token=session['oauth_token'])
     results = github.get('https://api.github.com/user').json()
 
     return jsonify(results)
@@ -55,22 +61,29 @@ def user_data():
 
 @app.route("/reviews", methods=["GET", "POST"])
 def create_issue():
-    github = OAuth2Session(app.config['CLIENT_ID'], token=session['oauth_token'])
+    github = OAuth2Session(app.config['CLIENT_ID'],
+                           token=session['oauth_token'])
     token = 'token:{0}'.format(github.token['access_token'])
-    headers = {'Authorization': token, 'Accept': 'application/vnd.github.moondragon+json'}
+    headers = {'Authorization': token,
+               'Accept': 'application/vnd.github.moondragon+json'}
 
     if request.method == 'POST':
         body = render_template('issue.md',
-                                    fingerprint=request.json['body']['fingerprint'],
-                                    desc=request.json['body']['description'],
-                                    links=request.json['body']['links'])
+                               fingerprint=request.json['body']['fingerprint'],
+                               desc=request.json['body']['description'],
+                               links=request.json['body']['links'])
         issue = {'title': request.json['title'], 'body': body}
-        
-        response = github.post('https://api.github.com/repos/public-fare/data/issues', data=json.dumps(issue), headers=headers)
-        
+
+        response = github.post(
+            'https://api.github.com/repos/public-fare/data/issues',
+            data=json.dumps(issue),
+            headers=headers
+        )
+
         return jsonify(response.json())
     elif request.method == 'GET':
-        response = github.get('https://api.github.com/repos/public-fare/data/issues').json()
+        response = github.get(
+            'https://api.github.com/repos/public-fare/data/issues').json()
         return jsonify({'issues': response})
     else:
         return redirect(url_for('.server_error'))
@@ -79,6 +92,7 @@ def create_issue():
 @app.errorhandler(404)
 def not_found(error):
     return render_template('404.html')
+
 
 @app.errorhandler(500)
 def server_error(error):


### PR DESCRIPTION
Now that data updates via NYPL site are happening, aggregated dishes can go stale. So
- stop baking lists of aggregated dishes into index term data
- run aggregate query only on checking saved term info, for display
- changes how saving is signalled
